### PR TITLE
remove artefact from testing

### DIFF
--- a/tutorials/time_series_forecasting_wilson_cowan/dataset.py
+++ b/tutorials/time_series_forecasting_wilson_cowan/dataset.py
@@ -45,7 +45,6 @@ class WSDataset(Dataset):
 				f"File {filename} not found in the list of available files: {list(self.FILE_ID_NAME.keys())}."
 			GoogleDriveDownloader(self.FILE_ID_NAME[filename], path, skip_existing=True, verbose=False).download()
 		ts = np.load(path)
-		ts = ts[:, :700]
 		n_neurons, n_shape = ts.shape
 		sample = np.random.randint(n_neurons, size=sample_size)
 		data = ts[sample, :]


### PR DESCRIPTION
In the dataset, the following code was seen:

`ts = ts[:700]
`
This code is an artefact of some testing that was done on data and should be removed.