### PR TITLE
Update cicd

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Gather new package version
       id: version
-      uses: anothrNick/github-tag-action@2.12.0
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
@@ -39,12 +39,19 @@ jobs:
 
     - name: Bump package version in pyproject.toml
       run: |
+        . ./venv/bin/activate
         poetry version ${{steps.version.outputs.new_tag}}
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add pyproject.toml
-        git diff-index --quiet HEAD || git commit -m "Updating version of pyproject.toml [skip actions]"
-        git push
+        git commit -m "Updating version of pyproject.toml"
+
+    - name: Push the new pyproject.toml
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        branch: main
+        force: true
 
     - name: Build dist
       run: |
@@ -66,14 +73,20 @@ jobs:
         force: true
         directory: dist
 
-    - name: Create Tag and Release
-      id: create_tag_and_release
-      uses: anothrNick/github-tag-action@2.12.0
+    - name: Create Tag
+      id: tag
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
         DEFAULT_BUMP: patch
         DRY_RUN: false
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.tag.outputs.new_tag }}
+        generate_release_notes: true
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "*" ]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 ![Tests Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/tests.yml/badge.svg)
 ![Dist Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/build_dist.yml/badge.svg)
 ![Doc Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/docs.yml/badge.svg)
-![Publish Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/publish.yml/badge.svg)
 
 
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve versioning, release processes, and branch handling. The most notable changes include downgrading the `github-tag-action` version, splitting the tag creation and release steps, and modifying branch triggers for the test workflow.

### Workflow updates for versioning and releases:

* [`.github/workflows/build_dist.yml`](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L33-R33): Downgraded `github-tag-action` from version `2.12.0` to `1.61.0` in both the "Gather new package version" and "Create Tag" steps. [[1]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L33-R33) [[2]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L69-R90)
* [`.github/workflows/build_dist.yml`](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495R42-R54): Replaced the inline commit and push commands with the `ad-m/github-push-action` for pushing changes to the `main` branch.
* [`.github/workflows/build_dist.yml`](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L69-R90): Separated the tag creation and release steps by introducing `softprops/action-gh-release` for generating release notes and creating releases.

### Workflow updates for branch handling:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL7-L8): Removed the `push` trigger for the `main` and `dev` branches, leaving only the `pull_request` trigger for all branches.