### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Gather new package version
       id: version
-      uses: anothrNick/github-tag-action@2.12.0
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
@@ -39,12 +39,19 @@ jobs:
 
     - name: Bump package version in pyproject.toml
       run: |
+        . ./venv/bin/activate
         poetry version ${{steps.version.outputs.new_tag}}
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add pyproject.toml
-        git diff-index --quiet HEAD || git commit -m "Updating version of pyproject.toml [skip actions]"
-        git push
+        git commit -m "Updating version of pyproject.toml"
+
+    - name: Push the new pyproject.toml
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        branch: main
+        force: true
 
     - name: Build dist
       run: |
@@ -66,14 +73,20 @@ jobs:
         force: true
         directory: dist
 
-    - name: Create Tag and Release
-      id: create_tag_and_release
-      uses: anothrNick/github-tag-action@2.12.0
+    - name: Create Tag
+      id: tag
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
         DEFAULT_BUMP: patch
         DRY_RUN: false
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.tag.outputs.new_tag }}
+        generate_release_notes: true
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "*" ]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 ![Tests Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/tests.yml/badge.svg)
 ![Dist Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/build_dist.yml/badge.svg)
 ![Doc Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/docs.yml/badge.svg)
-![Publish Workflow](https://github.com/NeuroTorch/NeuroTorch/actions/workflows/publish.yml/badge.svg)
 
 
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve package versioning, release management, and testing configurations. It also includes minor updates to the `README.md` file to reflect workflow changes. Below are the key changes grouped by theme:

### Workflow Improvements

* **Versioning and Release Management**:
  - Downgraded `github-tag-action` from version `2.12.0` to `1.61.0` in the `build_dist.yml` workflow for both version gathering and tag creation steps. [[1]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L33-R33) [[2]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L69-R90)
  - Replaced inline Git commands for pushing updates to `pyproject.toml` with the `github-push-action` for better maintainability and explicit branch targeting.
  - Split the "Create Tag and Release" step into separate "Create Tag" and "Create Release" steps, using `action-gh-release` to generate release notes.

* **Testing Workflow**:
  - Removed the `push` trigger for the `tests.yml` workflow, limiting it to `pull_request` events only.

### Documentation Update

* **README Updates**:
  - Removed the badge for the `publish.yml` workflow, reflecting its removal or deprecation.